### PR TITLE
Updated action version

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Send Notification
         run: |


### PR DESCRIPTION
Task today failed because they are deprecating node12.

The new version of the checkout action is v4 and uses node20.

Details of failed job: https://github.com/MartinoMensio/claimreview-data/actions/runs/6185545881